### PR TITLE
Fix incorrectly extracted GIF loop count value

### DIFF
--- a/YYImage/YYImageCoder.m
+++ b/YYImage/YYImageCoder.m
@@ -1973,16 +1973,19 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
         if (_type == YYImageTypePNG) { // use custom apng decoder and ignore multi-frame
             _frameCount = 1;
         }
-        if (_type == YYImageTypeGIF) { // get gif loop count
-            CFDictionaryRef properties = CGImageSourceCopyProperties(_source, NULL);
-            if (properties) {
-                CFTypeRef loop = CFDictionaryGetValue(properties, kCGImagePropertyGIFLoopCount);
-                if (loop) CFNumberGetValue(loop, kCFNumberNSIntegerType, &_loopCount);
-                CFRelease(properties);
-            }
+      if (_type == YYImageTypeGIF) { // get gif loop count
+        CFDictionaryRef properties = CGImageSourceCopyProperties(_source, NULL);
+        if (properties) {
+          CFDictionaryRef gif = CFDictionaryGetValue(properties, kCGImagePropertyGIFDictionary);
+          if (gif) {
+            CFTypeRef loop = CFDictionaryGetValue(gif, kCGImagePropertyGIFLoopCount);
+            if (loop) CFNumberGetValue(loop, kCFNumberNSIntegerType, &_loopCount);
+          }
+          CFRelease(properties);
         }
+      }
     }
-    
+  
     /*
      ICO, GIF, APNG may contains multi-frame.
      */


### PR DESCRIPTION
To obtain correct GIF loop count parameter we must firstly retrieve a dictionary with the global GIF properties using `kCGImagePropertyGIFDictionary` key.

For your convenience, here is an animation with a custom loop count so you can easily test how this fix works:
![loopcount3](https://cloud.githubusercontent.com/assets/10479469/14708872/3e672e7a-07d6-11e6-8d89-0392d1066de0.gif)