### PR TITLE
YYSpriteSheetImage memory issues

### DIFF
--- a/YYImage/YYImageCoder.m
+++ b/YYImage/YYImageCoder.m
@@ -2783,7 +2783,7 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
 }
 
 - (BOOL)yy_isDecodedForDisplay {
-    if (self.images.count > 1) return YES;
+    if (self.images.count > 1 || [self isKindOfClass:[YYSpriteSheetImage class]) return YES;
     NSNumber *num = objc_getAssociatedObject(self, @selector(yy_isDecodedForDisplay));
     return [num boolValue];
 }

--- a/YYImage/YYImageCoder.m
+++ b/YYImage/YYImageCoder.m
@@ -2783,7 +2783,7 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
 }
 
 - (BOOL)yy_isDecodedForDisplay {
-    if (self.images.count > 1 || [self isKindOfClass:[YYSpriteSheetImage class]) return YES;
+    if (self.images.count > 1 || [self isKindOfClass:[YYSpriteSheetImage class]]) return YES;
     NSNumber *num = objc_getAssociatedObject(self, @selector(yy_isDecodedForDisplay));
     return [num boolValue];
 }


### PR DESCRIPTION
This is a fix proposal for a crash because of lots of unreleased CG raster data (application is unloaded by jetsam).

When we had say 7-10 (or more) animated images on the same page animating at the same time, in instruments we can see that application memory usage is acceptable ~60mb, but "other processes" can be up to 1gb and growing (related to CG raster data). Looks like this issue is caused by the yy_imageByDecoded (YYCGImageCreateDecodedCopy to be more precise). Since `animatedImageFrameAtIndex:` for a sprite sheet image is the sprite atlas itself, thus whole atlas is copied for every frame of animation (we had 60 frames).

`yy_isDecodedForDisplay` is always YES for animated images (images.count > 1), so seems reasonable to return YES for a Sprite Sheet Images also.

After this fix 10+ sprite images on the screen are animating at the same time on old gen iPod (iOS 7) without any issues.