### PR TITLE
Verify secure coding for YYImage.

### DIFF
--- a/YYImage/YYImage.m
+++ b/YYImage/YYImage.m
@@ -212,6 +212,10 @@ static CGFloat _NSStringPathScale(NSString *string) {
     }
 }
 
++ (BOOL)supportsSecureCoding {
+    return  YES;
+}
+
 #pragma mark - protocol YYAnimatedImage
 
 - (NSUInteger)animatedImageFrameCount {


### PR DESCRIPTION
Exception thrown during data decoding: Class 'YYImage' has a superclass that supports secure coding, but 'YYImage' overrides -initWithCoder: and does not override +supportsSecureCoding. The class must implement +supportsSecureCoding and return YES to verify that its implementation of -initWithCoder: is secure coding compliant.