### PR TITLE
Change gif loop behaviour to works like most of the modern browsers

### DIFF
--- a/YYImage/YYImageCoder.m
+++ b/YYImage/YYImageCoder.m
@@ -1947,7 +1947,7 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
     _width = 0;
     _height = 0;
     _orientation = UIImageOrientationUp;
-    _loopCount = 0;
+    _loopCount = 1;
     dispatch_semaphore_wait(_framesLock, DISPATCH_TIME_FOREVER);
     _frames = nil;
     dispatch_semaphore_signal(_framesLock);
@@ -1979,7 +1979,15 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
                 CFDictionaryRef gif = CFDictionaryGetValue(properties, kCGImagePropertyGIFDictionary);
                 if (gif) {
                     CFTypeRef loop = CFDictionaryGetValue(gif, kCGImagePropertyGIFLoopCount);
-                    if (loop) CFNumberGetValue(loop, kCFNumberNSIntegerType, &_loopCount);
+                    if (loop) {
+                        NSUInteger metaLoopCount = 1; //it's 1 because CFNumberGetValue may failed
+                        Boolean loopCountNumberResult = CFNumberGetValue(loop, kCFNumberNSIntegerType, &metaLoopCount);
+                        if(!loopCountNumberResult || (loopCountNumberResult && metaLoopCount == 0)){
+                            _loopCount = 0;
+                        }else{
+                            _loopCount = metaLoopCount + 1;
+                        }
+                    }
                 }
                 CFRelease(properties);
             }


### PR DESCRIPTION
Hello. I was testing YYImage with react-native port (https://www.npmjs.com/package/react-native-yyimage) against loop behaviour. I found out that, library sets infinity loops when there is no loop count (Animation iterations from exiftool) in gif metadata. Other browsers sets default loop count = 1 when no metadata available. I have tested the same looped gifs on android, chrome, safari opera and mozilla FF and iOS. I don't know if you want to change default behaviour of YYImage but for my needs I changed it to works like the same way like on:

- android
- chrome
- safari
- opera 