### PR TITLE
Add a libwebp subpod

### DIFF
--- a/YYImage.podspec
+++ b/YYImage.podspec
@@ -25,4 +25,12 @@ Pod::Spec.new do |s|
     webp.ios.vendored_frameworks = 'Vendor/WebP.framework'
   end
 
+  s.subspec 'libwebp' do |libwebp|
+    libwebp.dependency 'YYImage/Core'
+    libwebp.dependency 'libwebp'
+    libwebp.xcconfig = { 
+      'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
+    }
+  end
+  
 end


### PR DESCRIPTION
Make it possible for YYImage to use a external libwebp dependency instead of the local static WebP.framework