### PR TITLE
fix memory leak bug when _incrBufferCount < 0

### DIFF
--- a/YYImage/YYAnimatedImageView.m
+++ b/YYImage/YYAnimatedImageView.m
@@ -491,7 +491,7 @@ typedef NS_ENUM(NSUInteger, YYAnimatedImageType) {
     LOCK(
          bufferedImage = buffer[@(nextIndex)];
          if (bufferedImage) {
-             if ((int)_incrBufferCount < _totalFrameCount) {
+             if ((int)_incrBufferCount < (int)_totalFrameCount) {
                  [buffer removeObjectForKey:@(nextIndex)];
              }
              [self willChangeValueForKey:@"currentAnimatedImageIndex"];


### PR DESCRIPTION
Related with the issue:
https://github.com/ibireme/YYImage/issues/95