### PR TITLE
Add support for tvOS

### DIFF
--- a/YYImage.podspec
+++ b/YYImage.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/ibireme/YYImage'
   s.platform     = :ios, '6.0'
   s.ios.deployment_target = '6.0'
+  s.tvos.deployment_target = "9.0"
   s.source       = { :git => 'https://github.com/ibireme/YYImage.git', :tag => s.version.to_s }
   
   s.requires_arc = true
@@ -17,7 +18,8 @@ Pod::Spec.new do |s|
     core.source_files = 'YYImage/*.{h,m}'
     core.public_header_files = 'YYImage/*.{h}'
     core.libraries = 'z'
-    core.frameworks = 'UIKit', 'CoreFoundation', 'QuartzCore', 'AssetsLibrary', 'ImageIO', 'Accelerate', 'MobileCoreServices'
+    core.tvos.frameworks = 'UIKit', 'CoreFoundation', 'QuartzCore', 'ImageIO', 'Accelerate', 'MobileCoreServices'
+    core.ios.frameworks = 'UIKit', 'CoreFoundation', 'QuartzCore', 'AssetsLibrary', 'ImageIO', 'Accelerate', 'MobileCoreServices'
   end
   
   s.subspec 'WebP' do |webp|

--- a/YYImage/YYImageCoder.m
+++ b/YYImage/YYImageCoder.m
@@ -16,7 +16,9 @@
 #import <Accelerate/Accelerate.h>
 #import <QuartzCore/QuartzCore.h>
 #import <MobileCoreServices/MobileCoreServices.h>
+#if TARGET_OS_IOS
 #import <AssetsLibrary/AssetsLibrary.h>
+#endif
 #import <objc/runtime.h>
 #import <pthread.h>
 #import <zlib.h>
@@ -2793,6 +2795,7 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
 }
 
 - (void)yy_saveToAlbumWithCompletionBlock:(void(^)(NSURL *assetURL, NSError *error))completionBlock {
+#if TARGET_OS_IOS
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSData *data = [self _yy_dataRepresentationForSystem:YES];
         ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
@@ -2807,8 +2810,11 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
             }
         }];
     });
+#else
+    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey : @"yy_saveToAlbumWithCompletionBlock failed: operation unavailable on Apple TV." };
+    completionBlock(nil, [NSError errorWithDomain:@"com.ibireme.webimage" code:-1 userInfo:userInfo]);
+#endif
 }
-
 - (NSData *)yy_imageDataRepresentation {
     return [self _yy_dataRepresentationForSystem:NO];
 }


### PR DESCRIPTION
This is a minor change to make the YYImage library work with tvOS. It has been tested in production.

The only necessary change to the code is to #if out the body of the `yy_saveToAlbumWithCompletionBlock` method when not running on iOS. The AssetsLibrary framework is not available on tvOS; calling this method on tvOS will simply result in the completion block being called with an error. All other aspects of the YYImage library work fine on tvOS.